### PR TITLE
ページの修正

### DIFF
--- a/pr2_1.html
+++ b/pr2_1.html
@@ -71,28 +71,28 @@
 <h1>実験用HTMLページ</h1>
 <h2>要素ならべ</h2>
 <div class="kawagoe">
-    <div class="radius1"></div>
+    <div class="red_line"></div>
+    <div class="red_line"></div>
+    <div class="red_line"></div>
     <div class="circle"></div>
-    <div class="radius2"></div>
-    <div class="circle"></div>
-    <div class="radius2"></div>
+    <div class="red_line"></div>
     <div class="red_line"></div>
 </div>
 <div class="rapid">
     <div class="blue_line"></div>
+    <div class="blue_line"></div>
     <div class="circle"></div>
     <div class="blue_line"></div>
     <div class="blue_line"></div>
-    <div class="circle"></div>
     <div class="circle"></div>
 </div>
 <div class="express">
     <div class="pink_line"></div>
-    <div class="radius2"></div>
-    <div class="radius1"></div>
+    <div class="pink_line"></div>
+    <div class="circle"></div>
     <div class="circle"></div>
     <div class="pink_line"></div>
-    <div class="pink_line"></div>
+    <div class="circle"></div>
 </div>
 <div class="local">
     <div class="circle"></div>
@@ -105,13 +105,13 @@
 <h2>カラーボックス</h2>
 <div style="background-color: gray;
             border: black 2px solid;
-            padding: 5px 30px 30px 30px;
+            padding: 30px 30px 30px 30px;
             margin-left: 20px;
             margin-right: 20px"
 ></div>
 <br>
 <div style="background-color: yellow;
-            border: black 2px soid;
+            border: black 2px solid;
             padding: 30px 30px 30px 30px;
             margin-left: 20px;
             margin-right: 20px"
@@ -131,14 +131,14 @@
             margin-right: 20px"
 ></div>
 <br>
-<span style="background-color: purple;
+<div style="background-color: purple;
             border: black 2px solid;
             padding: 30px 30px 30px 30px;
             margin-left: 20px;
             margin-right: 20px"
-></span>
+></div>
 <br>
-<div style="backgrund-color: red;
+<div style="background-color: red;
             border: black 2px solid;
             padding: 30px 30px 30px 30px;
             margin-left: 20px;


### PR DESCRIPTION
＜要素ならべ＞
画面仕様書と要素が違う個所は、画面仕様書と同じ要素になるように置換した。
＜カラーボックス＞
灰色は上下が短かったため、paddingを仕様書通りに修正した。
黄色は枠線がなかったため、枠線の部分をborderの表記に修正した。
紫色は横に長い長方形ではなかったため、styleの表記をdivに修正した。
赤色は箱の中の色が抜けていたため、background-colorの誤字を修正した。